### PR TITLE
Fixed rare UI bug

### DIFF
--- a/campaign/record_char_actions.xml
+++ b/campaign/record_char_actions.xml
@@ -121,7 +121,7 @@
 		<playercontrol />
 		<script file="campaign/scripts/itemgroup.lua" />
 		<sheetdata>
-			<windowtitlebar_char name="title" />
+			<windowtitlebar_charselect name="title" />
 			<anchor_title_charsheethelper name="contentanchor" />
 			<windowlist name="list">
 				<anchored to="contentanchor">


### PR DESCRIPTION
When grouping items into same group on action bar, it would throw errors when trying to view what items are in group.